### PR TITLE
Ignore neighbours max when calculating unlockables

### DIFF
--- a/CookieClicker/Horticookie.js
+++ b/CookieClicker/Horticookie.js
@@ -810,9 +810,11 @@ Horticookie.launch = function(){
 			
 			if(mut.type == Horticookie.recipeCodes.NORMAL){
 				for(var j = 0; j < mut.neighsM.length; j++){
+					if(mut.neighsM[j].isMax) continue;
 					if(!M.plants[mut.neighsM[j].plant].unlocked) unlockable = false;
 				}
 				for(var j = 0; j < mut.neighs.length; j++){
+					if(mut.neighs[j].isMax) continue;
 					if(!M.plants[mut.neighs[j].plant].unlocked) unlockable = false;
 				}
 				


### PR DESCRIPTION
Fixes that white mildew could never be unlocked