### PR TITLE
Optional style in AppendOptionsMenu

### DIFF
--- a/CookieClicker/Beta/CCSE.js
+++ b/CookieClicker/Beta/CCSE.js
@@ -2249,12 +2249,23 @@ CCSE.launch = function(){
 	/*=====================================================================================
 	Menu functions
 	=======================================================================================*/
-	CCSE.AppendOptionsMenu = function(inp){
+	CCSE.AppendOptionsMenu = function(inp, style = 1){
 		// Accepts inputs of either string or div
+		// Choose div class based on given style. A style of 0 will have no class.
+		var divClass;
+		switch (style) {
+			case 1:
+				divClass = "block";
+				break;
+			case 2:
+				divClass = "framed";
+				break;
+		}
+		
 		var div = document.createElement('div');
 		//div.className = "framed";
 		//div.style= "margin:4px 48px;";
-		div.innerHTML = '<div class="block" style="padding:0px;margin:8px 4px;"><div class="subsection" style="padding:0px;"></div></div>';
+		div.innerHTML = '<div' + (divClass ? ` class="${ divClass }" ` : '') + 'style="padding:0px;margin:8px 4px;"><div class="subsection" style="padding:0px;"></div></div>';
 		var div2 = div.children[0].children[0];
 		//var div2 = div.children[0];
 		

--- a/CookieClicker/CCSE.js
+++ b/CookieClicker/CCSE.js
@@ -2249,12 +2249,23 @@ CCSE.launch = function(){
 	/*=====================================================================================
 	Menu functions
 	=======================================================================================*/
-	CCSE.AppendOptionsMenu = function(inp){
+	CCSE.AppendOptionsMenu = function(inp, style = 1){
 		// Accepts inputs of either string or div
+		// Choose div class based on given style. A style of 0 will have no class.
+		var divClass;
+		switch (style) {
+			case 1:
+				divClass = "block";
+				break;
+			case 2:
+				divClass = "framed";
+				break;
+		}
+
 		var div = document.createElement('div');
 		//div.className = "framed";
 		//div.style= "margin:4px 48px;";
-		div.innerHTML = '<div class="block" style="padding:0px;margin:8px 4px;"><div class="subsection" style="padding:0px;"></div></div>';
+		div.innerHTML = '<div' + (divClass ? ` class="${ divClass }" ` : '') + 'style="padding:0px;margin:8px 4px;"><div class="subsection" style="padding:0px;"></div></div>';
 		var div2 = div.children[0].children[0];
 		//var div2 = div.children[0];
 		

--- a/CookieClicker/SteamMods/CCSE/main.js
+++ b/CookieClicker/SteamMods/CCSE/main.js
@@ -2246,12 +2246,23 @@ CCSE.launch = function(){
 	/*=====================================================================================
 	Menu functions
 	=======================================================================================*/
-	CCSE.AppendOptionsMenu = function(inp){
+	CCSE.AppendOptionsMenu = function(inp, style = 1){
 		// Accepts inputs of either string or div
+		// Choose div class based on given style. A style of 0 will have no class.
+		var divClass;
+		switch (style) {
+			case 1:
+				divClass = "block";
+				break;
+			case 2:
+				divClass = "framed";
+				break;
+		}
+		
 		var div = document.createElement('div');
 		//div.className = "framed";
 		//div.style= "margin:4px 48px;";
-		div.innerHTML = '<div class="block" style="padding:0px;margin:8px 4px;"><div class="subsection" style="padding:0px;"></div></div>';
+		div.innerHTML = '<div' + (divClass ? ` class="${ divClass }" ` : '') + 'style="padding:0px;margin:8px 4px;"><div class="subsection" style="padding:0px;"></div></div>';
 		var div2 = div.children[0].children[0];
 		//var div2 = div.children[0];
 		


### PR DESCRIPTION
This is a non-breaking change that adds an easy way for options menus to have different styles.

AppendOptionsMenu now has an optional 2nd parameter 'style', which can be used like so:

```js
CCSE.AppendOptionsMenu('<div class="section">Nothing</div>', 0);
CCSE.AppendOptionsMenu('<div class="section">Bordered</div>', 1);
CCSE.AppendOptionsMenu('<div class="section">Framed</div>', 2);
CCSE.AppendOptionsMenu('<div class="section">Default (bordered)</div>');
```

Which results in this:
![image](https://github.com/klattmose/klattmose.github.io/assets/38600896/59729f00-7a98-4854-aaf9-efde7e7d8857)
